### PR TITLE
Updating LocalSettings.php settings for Kaiserreich Wiki per T13504

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -4770,6 +4770,9 @@ $wgConf->settings += [
 			'flow-topiclist-sortby' => 'newest',
 			'usecodemirror' => 1,
 		],
+		'+kaiserreichwiki' => [
+			'vector-theme' => 'night',
+		],
 		'+kirbywiki' => [
 			'thumbsize' => 3,
 		],


### PR DESCRIPTION
Updating the `LocalSettings.php` entry for the Kaiserreich Wiki per [T13504](https://issue-tracker.miraheze.org/T13504).